### PR TITLE
Remove unnessesary "|" symbol when there is only one file

### DIFF
--- a/src/@episerver/forms-sdk/src/form-submit/formSubmit.ts
+++ b/src/@episerver/forms-sdk/src/form-submit/formSubmit.ts
@@ -142,7 +142,7 @@ export class FormSubmitter {
 
                         // always send file name to server if existed to handle case upload file then click back
                         // charactor | cannot be used in filename and then is safe for splitting later
-                        if(idx > 0){
+                        if(idx > 0 && idx != files.length - 1){
                             fileNames += " | "
                         }
                         

--- a/src/@episerver/forms-sdk/src/helpers/buildConfirmationMessage.ts
+++ b/src/@episerver/forms-sdk/src/helpers/buildConfirmationMessage.ts
@@ -20,10 +20,11 @@ export function getStringValue(element: FormSubmission) {
     if (Array.isArray(value) && value.length > 0 &&
         value[0] !== null && typeof value[0] === "object") {
         const fileList = value
+        const numberOfFiles = fileList.length
         let fileNames = ""
-        for (let i = 0; i < fileList.length; i++) {
+        for (let i = 0; i < numberOfFiles; i++) {
             fileNames += `${fileList[i].name}`
-            if (fileList.length > 0) {
+            if (i > 0 && i != numberOfFiles - 1) {
                 fileNames += " | "
             }
         }


### PR DESCRIPTION
Fixes: AFORM-3942