### PR TITLE
Fix cannot start management site

### DIFF
--- a/samples/ManagementSite/Alloy.ManagementSite.csproj
+++ b/samples/ManagementSite/Alloy.ManagementSite.csproj
@@ -5,8 +5,8 @@
 		<CmsUIVersion>12.30.0</CmsUIVersion>
 		<CmsCoreVersion>12.21.4</CmsCoreVersion>
 		<HeadlessFormVersion>1.0.0</HeadlessFormVersion>
-		<ContentApiVersion>12.20.1</ContentApiVersion>
 		<FormVersion>5.9.0</FormVersion>
+		<ContentApiVersion>3.10.2</ContentApiVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="EPiServer.CMS.AspNetCore" Version="$(CmsCoreVersion)" />
@@ -30,7 +30,8 @@
 		<PackageReference Include="Optimizely.Cms.Forms.ContentGraph" Version="$(HeadlessFormVersion)" />
 		<PackageReference Include="Optimizely.Cms.Forms.Core" Version="$(HeadlessFormVersion)" />
 		<PackageReference Include="Optimizely.Cms.Forms.Service" Version="$(HeadlessFormVersion)" />
-		<PackageReference Include="Optimizely.ContentGraph.Cms" Version="3.5.1" />
+		<PackageReference Include="Optimizely.ContentGraph.Cms" Version="3.9.0" />
+		<PackageReference Include="EPiServer.ContentDeliveryApi.Core" Version="$(ContentApiVersion)" />
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />

--- a/samples/ManagementSite/Alloy.ManagementSite.csproj
+++ b/samples/ManagementSite/Alloy.ManagementSite.csproj
@@ -31,6 +31,7 @@
 		<PackageReference Include="Optimizely.Cms.Forms.Core" Version="$(HeadlessFormVersion)" />
 		<PackageReference Include="Optimizely.Cms.Forms.Service" Version="$(HeadlessFormVersion)" />
 		<PackageReference Include="Optimizely.ContentGraph.Cms" Version="3.9.0" />
+		<PackageReference Include="EPiServer.ContentDeliveryApi.Cms" Version="$(ContentApiVersion)" />
 		<PackageReference Include="EPiServer.ContentDeliveryApi.Core" Version="$(ContentApiVersion)" />
 	</ItemGroup>
 	<ItemGroup>

--- a/samples/ManagementSite/Startup.cs
+++ b/samples/ManagementSite/Startup.cs
@@ -23,6 +23,7 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using EPiServer.DependencyInjection;
 using Optimizely.Cms.Forms.DependencyInjection;
 using Optimizely.Cms.Forms;
+using EPiServer.Cms.Shell.UI;
 
 namespace Alloy.ManagementSite
 {
@@ -46,7 +47,6 @@ namespace Alloy.ManagementSite
             if (_environment.IsDevelopment())
             {
                 //NETCORE: Consider add appsettings support for this
-
                 services.Configure<StaticFileOptions>(o =>
                 {
                     o.OnPrepareResponse = context =>
@@ -88,7 +88,9 @@ namespace Alloy.ManagementSite
                 .Configure<ExternalApplicationOptions>(options => options.OptimizeForDelivery = true)
                 .ConfigureDisplayOptions()
                 .AddContentDelivery(managementSiteOptions)
-                .ConfigureDxp(managementSiteOptions, _configuration);
+                .ConfigureDxp(managementSiteOptions, _configuration)
+                .AddAdminUserRegistration(options => options.Behavior = RegisterAdminUserBehaviors.Enabled |
+                                                                    RegisterAdminUserBehaviors.LocalRequestsOnly);
 
             services.AddCors(opts =>
             {
@@ -192,6 +194,14 @@ namespace Alloy.ManagementSite
                 foreach (var key in _options.EncryptionCredentials.Select(c => c.Key))
                 {
                     client.EncryptionKeys.Add(key);
+                }
+            }
+
+            foreach (var client in options.OpenIDConnectClients)
+            {
+                foreach (var key in _options.SigningCredentials.Select(c => c.Key))
+                {
+                    client.SigningKeys.Add(key);
                 }
             }
         }


### PR DESCRIPTION
Upgrade Content Graph version
Explicitly set version for Content Delivery Coree

![image](https://github.com/user-attachments/assets/9aac22c6-84f1-4ac8-9162-16c08b3debf4)