### PR TITLE
Remove Beta tag in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿# Headless Form JS SDK (beta release)
+﻿# Optimizely Headless Form JS SDK
 
 This JS SDK package helps render a form based on metadata taken from the Headless Form API. In this package, there are 2 main parts:
 

--- a/src/@episerver/forms-react/README.md
+++ b/src/@episerver/forms-react/README.md
@@ -1,4 +1,4 @@
-# Headless Form React Documentation
+# Headless Form React SDK Documentation
 There are two components can be used when install package `@episerver/forms-react`:
 ## Form 
 ### Description


### PR DESCRIPTION
The first SDK version was released nearly two years already, we should remove the beta tag.